### PR TITLE
exp: common interface for properties

### DIFF
--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -42,16 +42,14 @@ type MessageProperties struct {
 	SourceID        string    `json:"sourceID" validate:"required"`
 	ReceivedAt      time.Time `json:"receivedAt" validate:"required"`
 	RequestIP       string    `json:"requestIP" validate:"required"`
-	DestinationID   string    `json:"destinationID,omitempty"`
-	UserID          string    `json:"userID,omitempty"`
-	SourceJobRunID  string    `json:"sourceJobRunID,omitempty"`
-	SourceTaskRunID string    `json:"sourceTaskRunID,omitempty"`
-	TraceID         string    `json:"traceID,omitempty"`
-	SourceType      string    `json:"sourceType,omitempty"`
-	Reason          string    `json:"reason,omitempty"`
-	Stage           string    `json:"stage,omitempty"`
+	DestinationID   string    `json:"destinationID,omitempty"`   // optional
+	UserID          string    `json:"userID,omitempty"`          // optional
+	SourceJobRunID  string    `json:"sourceJobRunID,omitempty"`  // optional
+	SourceTaskRunID string    `json:"sourceTaskRunID,omitempty"` // optional
+	TraceID         string    `json:"traceID,omitempty"`         // optional
 }
 
+// FromMap populates MessageProperties from a map.
 func (m *MessageProperties) FromMap(properties map[string]string) error {
 	receivedAt, err := time.Parse(time.RFC3339Nano, properties[mapKeyReceivedAt])
 	if err != nil {
@@ -61,37 +59,32 @@ func (m *MessageProperties) FromMap(properties map[string]string) error {
 	m.MessageID = properties[mapKeyMessageID]
 	m.RoutingKey = properties[mapKeyRoutingKey]
 	m.WorkspaceID = properties[mapKeyWorkspaceID]
-	m.SourceID = properties[mapKeySourceID]
-	m.ReceivedAt = receivedAt
 	m.RequestIP = properties[mapKeyRequestIP]
-	m.DestinationID = properties[mapKeyDestinationID]
 	m.UserID = properties[mapKeyUserID]
+	m.SourceID = properties[mapKeySourceID]
+	m.DestinationID = properties[mapKeyDestinationID]
+	m.ReceivedAt = receivedAt
 	m.SourceJobRunID = properties[mapKeySourceJobRunID]
 	m.SourceTaskRunID = properties[mapKeySourceTaskRunID]
 	m.TraceID = properties[mapKeyTraceID]
-	m.SourceType = properties[mapKeySourceType]
-	m.Reason = properties[mapKeyReason]
-	m.Stage = properties[mapKeyStage]
 
 	return nil
 }
 
+// ToMap converts MessageProperties to a map.
 func (m MessageProperties) ToMap() map[string]string {
 	return map[string]string{
 		mapKeyMessageID:       m.MessageID,
 		mapKeyRoutingKey:      m.RoutingKey,
 		mapKeyWorkspaceID:     m.WorkspaceID,
+		mapKeyUserID:          m.UserID,
 		mapKeySourceID:        m.SourceID,
 		mapKeyDestinationID:   m.DestinationID,
 		mapKeyRequestIP:       m.RequestIP,
 		mapKeyReceivedAt:      m.ReceivedAt.Format(time.RFC3339Nano),
-		mapKeyUserID:          m.UserID,
 		mapKeySourceJobRunID:  m.SourceJobRunID,
 		mapKeySourceTaskRunID: m.SourceTaskRunID,
 		mapKeyTraceID:         m.TraceID,
-		mapKeySourceType:      m.SourceType,
-		mapKeyReason:          m.Reason,
-		mapKeyStage:           m.Stage,
 	}
 }
 
@@ -103,6 +96,7 @@ type WebhookProperties struct {
 	Stage       string `json:"stage,omitempty" validate:"required"`
 }
 
+// FromMap populates WebhookProperties from a map.
 func (w *WebhookProperties) FromMap(properties map[string]string) error {
 	w.WorkspaceID = properties[mapKeyWorkspaceID]
 	w.SourceID = properties[mapKeySourceID]
@@ -113,6 +107,7 @@ func (w *WebhookProperties) FromMap(properties map[string]string) error {
 	return nil
 }
 
+// ToMap converts WebhookProperties to a map.
 func (w WebhookProperties) ToMap() map[string]string {
 	return map[string]string{
 		mapKeyWorkspaceID: w.WorkspaceID,
@@ -123,14 +118,17 @@ func (w WebhookProperties) ToMap() map[string]string {
 	}
 }
 
+// FromMapProperties populates a Properties object from a map.
 func FromMapProperties(properties map[string]string, prop Properties) error {
 	return prop.FromMap(properties)
 }
 
+// ToMapProperties converts a Properties object to a map.
 func ToMapProperties(properties Properties) map[string]string {
 	return properties.ToMap()
 }
 
+// NewMessageValidator creates a new validator for Message.
 func NewMessageValidator() func(msg *Message) error {
 	validate := validator.New(validator.WithRequiredStructEnabled())
 

--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -20,6 +20,9 @@ const (
 	mapKeySourceJobRunID  = "sourceJobRunID"
 	mapKeySourceTaskRunID = "sourceTaskRunID"
 	mapKeyTraceID         = "traceID"
+	mapKeySourceType      = "sourceType"
+	mapKeyReason          = "reason"
+	mapKeyStage           = "stage"
 )
 
 type Message struct {
@@ -39,6 +42,9 @@ type MessageProperties struct {
 	SourceJobRunID  string    `json:"sourceJobRunID,omitempty"`  // optional
 	SourceTaskRunID string    `json:"sourceTaskRunID,omitempty"` // optional
 	TraceID         string    `json:"traceID,omitempty"`         // optional
+	SourceType      string    `json:"sourceType,omitempty"`      // optional
+	Reason          string    `json:"reason,omitempty"`          // optional
+	Stage           string    `json:"stage,omitempty"`           // optional
 }
 
 // FromMapProperties converts a property map to MessageProperties.
@@ -60,6 +66,9 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		SourceJobRunID:  properties[mapKeySourceJobRunID],
 		SourceTaskRunID: properties[mapKeySourceTaskRunID],
 		TraceID:         properties[mapKeyTraceID],
+		SourceType:      properties[mapKeySourceType],
+		Reason:          properties[mapKeyReason],
+		Stage:           properties[mapKeyStage],
 	}, nil
 }
 
@@ -77,6 +86,9 @@ func ToMapProperties(properties MessageProperties) map[string]string {
 		mapKeySourceJobRunID:  properties.SourceJobRunID,
 		mapKeySourceTaskRunID: properties.SourceTaskRunID,
 		mapKeyTraceID:         properties.TraceID,
+		mapKeySourceType:      properties.SourceType,
+		mapKeyReason:          properties.Reason,
+		mapKeyStage:           properties.Stage,
 	}
 }
 

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -24,9 +24,6 @@ func TestMessage(t *testing.T) {
 			"sourceJobRunID":  "sourceJobRunID",
 			"sourceTaskRunID": "sourceTaskRunID",
 			"traceID":         "traceID",
-			"sourceType":      "sourceType",
-			"reason":          "reason",
-			"stage":           "stage",
 		}
 
 		var msg stream.MessageProperties
@@ -45,9 +42,6 @@ func TestMessage(t *testing.T) {
 			SourceJobRunID:  "sourceJobRunID",
 			SourceTaskRunID: "sourceTaskRunID",
 			TraceID:         "traceID",
-			SourceType:      "sourceType",
-			Reason:          "reason",
-			Stage:           "stage",
 		}, msg)
 
 		propertiesOut := stream.ToMapProperties(&msg)

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -24,6 +24,9 @@ func TestMessage(t *testing.T) {
 			"sourceJobRunID":  "sourceJobRunID",
 			"sourceTaskRunID": "sourceTaskRunID",
 			"traceID":         "traceID",
+			"sourceType":      "sourceType",
+			"reason":          "reason",
+			"stage":           "stage",
 		}
 
 		msg, err := stream.FromMapProperties(input)
@@ -41,6 +44,9 @@ func TestMessage(t *testing.T) {
 			SourceJobRunID:  "sourceJobRunID",
 			SourceTaskRunID: "sourceTaskRunID",
 			TraceID:         "traceID",
+			SourceType:      "sourceType",
+			Reason:          "reason",
+			Stage:           "stage",
 		}, msg)
 
 		propertiesOut := stream.ToMapProperties(msg)

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -29,7 +29,8 @@ func TestMessage(t *testing.T) {
 			"stage":           "stage",
 		}
 
-		msg, err := stream.FromMapProperties(input)
+		var msg stream.MessageProperties
+		err := stream.FromMapProperties(input, &msg)
 		require.NoError(t, err)
 
 		require.Equal(t, stream.MessageProperties{
@@ -49,13 +50,14 @@ func TestMessage(t *testing.T) {
 			Stage:           "stage",
 		}, msg)
 
-		propertiesOut := stream.ToMapProperties(msg)
+		propertiesOut := stream.ToMapProperties(&msg)
 		require.Equal(t, input, propertiesOut)
 
 		t.Run("invalid receivedAt format", func(t *testing.T) {
-			msg, err := stream.FromMapProperties(map[string]string{
+			var msg stream.MessageProperties
+			err := stream.FromMapProperties(map[string]string{
 				"receivedAt": time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.Kitchen),
-			})
+			}, &msg)
 			require.Empty(t, msg)
 			require.EqualError(t, err, `parsing receivedAt: parsing time "2:30AM" as "2006-01-02T15:04:05.999999999Z07:00": cannot parse "2:30AM" as "2006"`)
 		})
@@ -86,11 +88,11 @@ func TestMessage(t *testing.T) {
 			}
 		}`
 
-		msg := stream.Message{}
+		msg := stream.Message{Properties: &stream.MessageProperties{}}
 		err := json.Unmarshal([]byte(input), &msg)
 		require.NoError(t, err)
 		require.Equal(t, stream.Message{
-			Properties: stream.MessageProperties{
+			Properties: &stream.MessageProperties{
 				MessageID:       "messageID",
 				RoutingKey:      "routingKey",
 				WorkspaceID:     "workspaceID",
@@ -121,7 +123,7 @@ func TestMessage(t *testing.T) {
 		validator := stream.NewMessageValidator()
 
 		msg := stream.Message{
-			Properties: stream.MessageProperties{
+			Properties: &stream.MessageProperties{
 				MessageID:   "messageID",
 				RoutingKey:  "routingKey",
 				WorkspaceID: "workspaceID",
@@ -144,7 +146,7 @@ func TestMessage(t *testing.T) {
 		validator := stream.NewMessageValidator()
 
 		msg := stream.Message{
-			Properties: stream.MessageProperties{
+			Properties: &stream.MessageProperties{
 				MessageID:   "",
 				RoutingKey:  "routingKey",
 				WorkspaceID: "workspaceID",


### PR DESCRIPTION
# Description

- Generic properties

### Changes we would need in src-router
```GO
From:
properties, err := schemas.FromMapProperties(msg.Properties())

To:
var p schemas.MessageProperties
err := schemas.FromMapProperties(pulsarMsg.Properties(), &p)
```
```GO
Since we are using stream.Message and directly accessing `message.Properies` which is now been converted interface, in order to access ReceivedAt we can do it via some casting. or provide an additional struct for stream.Message which contains MessageProperties and Payload.
From:
for _, msg := range msgHandlerBatch {
	pc.measureDoneLag.Since(msg.Properties.ReceivedAt)
}

To:
for _, msg := range msgHandlerBatch {
	pc.measureDoneLag.Since(msg.Properties.(*schemas.MessageProperties).ReceivedAt)
}
```
