### PR TITLE
fix: release please

### DIFF
--- a/.github/workflows/release-please-config.json
+++ b/.github/workflows/release-please-config.json
@@ -1,0 +1,10 @@
+{
+    "pull-request-title-pattern": "chore: release ${version}",
+    "bump-minor-pre-major": true,
+    "changelog-types": "[{\"type\":\"feat\",\"section\":\"Features\",\"hidden\":false},{\"type\":\"fix\",\"section\":\"Bug Fixes\",\"hidden\":false},{\"type\":\"chore\",\"section\":\"Miscellaneous\",\"hidden\":false},{\"type\":\"refactor\",\"section\":\"Miscellaneous\",\"hidden\":false},{\"type\":\"test\",\"section\":\"Miscellaneous\",\"hidden\":false},{\"type\":\"doc\",\"section\":\"Documentation\",\"hidden\":false}]",
+    "packages": {
+        "go/stream": {
+            "package-name": "rudder-schemas"
+        }
+    }
+}

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,12 +11,9 @@ jobs:
         shell: bash
         run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
         id: extract_branch
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.PAT }}
-          pull-request-title-pattern: "chore: release ${version}"
           release-type: go
-          package-name: rudder-schemas
-          default-branch: ${{ steps.extract_branch.outputs.branch }}
-          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"chore","section":"Miscellaneous","hidden":false},{"type":"refactor","section":"Miscellaneous","hidden":false},{"type":"test","section":"Miscellaneous","hidden":false},{"type":"doc","section":"Documentation","hidden":false}]'
-          bump-minor-pre-major: true
+          config-file: 'release-please-config.json'
+          target-branch: ${{ steps.extract_branch.outputs.branch }}


### PR DESCRIPTION
# Description

An attempt to fix release please.

> If you were previously configuring advanced options via GitHub action inputs, you will need to configure via the release-please manifest configuration instead.

* https://github.com/marketplace/actions/release-please-action#package-options
* https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md

## Linear Ticket

< No_Linear_Link >

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
