### PR TITLE
fix: message properties should contain reqType instead of messageID [PIPE-1557]

### DIFF
--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -36,7 +36,7 @@ type Message struct {
 }
 
 type MessageProperties struct {
-	RequestType          string    `json:"requestType" validate:"required"`
+	RequestType          string    `json:"requestType,omitempty"` // optional, make it required in the next version
 	RoutingKey           string    `json:"routingKey" validate:"required"`
 	WorkspaceID          string    `json:"workspaceID" validate:"required"`
 	SourceID             string    `json:"sourceID" validate:"required"`

--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -11,7 +11,7 @@ import (
 const (
 	StageWebhook = "webhook"
 
-	mapKeyMessageID            = "messageID"
+	mapKeyRequestType          = "requestType"
 	mapKeyRoutingKey           = "routingKey"
 	mapKeyWorkspaceID          = "workspaceID"
 	mapKeySourceID             = "sourceID"
@@ -36,7 +36,7 @@ type Message struct {
 }
 
 type MessageProperties struct {
-	MessageID            string    `json:"messageID" validate:"required"`
+	RequestType          string    `json:"requestType" validate:"required"`
 	RoutingKey           string    `json:"routingKey" validate:"required"`
 	WorkspaceID          string    `json:"workspaceID" validate:"required"`
 	SourceID             string    `json:"sourceID" validate:"required"`
@@ -64,7 +64,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 	}
 
 	return MessageProperties{
-		MessageID:            properties[mapKeyMessageID],
+		RequestType:          properties[mapKeyRequestType],
 		RoutingKey:           properties[mapKeyRoutingKey],
 		WorkspaceID:          properties[mapKeyWorkspaceID],
 		RequestIP:            properties[mapKeyRequestIP],
@@ -87,7 +87,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 // ToMapProperties converts a Message to map properties.
 func ToMapProperties(properties MessageProperties) map[string]string {
 	m := map[string]string{
-		mapKeyMessageID:       properties.MessageID,
+		mapKeyRequestType:     properties.RequestType,
 		mapKeyRoutingKey:      properties.RoutingKey,
 		mapKeyWorkspaceID:     properties.WorkspaceID,
 		mapKeyUserID:          properties.UserID,

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -13,7 +13,7 @@ import (
 func TestMessage(t *testing.T) {
 	t.Run("properties to/from: pulsar", func(t *testing.T) {
 		input := map[string]string{
-			"messageID":       "messageID",
+			"requestType":     "requestType",
 			"routingKey":      "routingKey",
 			"workspaceID":     "workspaceID",
 			"userID":          "userID",
@@ -33,7 +33,7 @@ func TestMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, stream.MessageProperties{
-			MessageID:       "messageID",
+			RequestType:     "requestType",
 			RoutingKey:      "routingKey",
 			WorkspaceID:     "workspaceID",
 			UserID:          "userID",
@@ -63,7 +63,7 @@ func TestMessage(t *testing.T) {
 
 	t.Run("properties to/from: pulsar with webhook stage", func(t *testing.T) {
 		input := map[string]string{
-			"messageID":            "messageID",
+			"requestType":          "requestType",
 			"routingKey":           "routingKey",
 			"workspaceID":          "workspaceID",
 			"userID":               "userID",
@@ -86,7 +86,7 @@ func TestMessage(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, stream.MessageProperties{
-			MessageID:            "messageID",
+			RequestType:          "requestType",
 			RoutingKey:           "routingKey",
 			WorkspaceID:          "workspaceID",
 			UserID:               "userID",
@@ -113,7 +113,7 @@ func TestMessage(t *testing.T) {
 		input := `
 		{
 			"properties": {
-				"messageID": "messageID",
+				"requestType": "requestType",
 				"routingKey": "routingKey",
 				"workspaceID": "workspaceID",
 				"userID": "userID",
@@ -142,7 +142,7 @@ func TestMessage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, stream.Message{
 			Properties: stream.MessageProperties{
-				MessageID:       "messageID",
+				RequestType:     "requestType",
 				RoutingKey:      "routingKey",
 				WorkspaceID:     "workspaceID",
 				UserID:          "userID",
@@ -175,7 +175,7 @@ func TestMessage(t *testing.T) {
 		input := `
 		{
 			"properties": {
-				"messageID": "messageID",
+				"requestType": "requestType",
 				"routingKey": "routingKey",
 				"workspaceID": "workspaceID",
 				"userID": "userID",
@@ -207,7 +207,7 @@ func TestMessage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, stream.Message{
 			Properties: stream.MessageProperties{
-				MessageID:       "messageID",
+				RequestType:     "requestType",
 				RoutingKey:      "routingKey",
 				WorkspaceID:     "workspaceID",
 				UserID:          "userID",
@@ -243,7 +243,7 @@ func TestMessage(t *testing.T) {
 
 		msg := stream.Message{
 			Properties: stream.MessageProperties{
-				MessageID:   "messageID",
+				RequestType: "requestType",
 				RoutingKey:  "routingKey",
 				WorkspaceID: "workspaceID",
 				SourceID:    "sourceID",
@@ -266,7 +266,7 @@ func TestMessage(t *testing.T) {
 
 		msg := stream.Message{
 			Properties: stream.MessageProperties{
-				MessageID:   "",
+				RequestType: "",
 				RoutingKey:  "routingKey",
 				WorkspaceID: "workspaceID",
 				SourceID:    "sourceID",
@@ -277,6 +277,6 @@ func TestMessage(t *testing.T) {
 		}
 
 		err := validator(&msg)
-		require.EqualError(t, err, "Key: 'Message.Properties.MessageID' Error:Field validation for 'MessageID' failed on the 'required' tag")
+		require.EqualError(t, err, "Key: 'Message.Properties.RequestType' Error:Field validation for 'RequestType' failed on the 'required' tag")
 	})
 }

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -266,9 +266,9 @@ func TestMessage(t *testing.T) {
 
 		msg := stream.Message{
 			Properties: stream.MessageProperties{
-				RequestType: "",
+				RequestType: "requestType",
 				RoutingKey:  "routingKey",
-				WorkspaceID: "workspaceID",
+				WorkspaceID: "",
 				SourceID:    "sourceID",
 				RequestIP:   "10.29.13.20",
 				ReceivedAt:  time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
@@ -277,6 +277,6 @@ func TestMessage(t *testing.T) {
 		}
 
 		err := validator(&msg)
-		require.EqualError(t, err, "Key: 'Message.Properties.RequestType' Error:Field validation for 'RequestType' failed on the 'required' tag")
+		require.EqualError(t, err, "Key: 'Message.Properties.WorkspaceID' Error:Field validation for 'WorkspaceID' failed on the 'required' tag")
 	})
 }


### PR DESCRIPTION
# Description

message properties should contain reqType instead of messageID since ingestion will no longer have messageID and gw infers it. Also, reqType should be passed to gw.

## Linear Ticket

https://linear.app/rudderstack/issue/PIPE-1557/payload-should-not-be-modified-in-ingestionsvc

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
