### PR TITLE
fix: update GitHub Actions workflow and release config

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -9,7 +9,8 @@ jobs:
     steps:
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: |
+          echo "branch=$(echo "${GITHUB_REF#refs/heads/}")" >> $GITHUB_OUTPUT
         id: extract_branch
       - uses: googleapis/release-please-action@v4
         with:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,9 @@
     "pull-request-title-pattern": "chore: release ${version}",
     "bump-minor-pre-major": true,
     "packages": {
-        ".": {}
+        ".": {
+            "release-type": "go",
+            "include-component-in-tag": false
+        }
     }
 }


### PR DESCRIPTION
# Description

- Migrate deprecated set-output command in release-please workflow to use GITHUB_OUTPUT
- Configure release-type as 'go' and disable component-in-tag in release-please configuration

## Linear Ticket

-

## Security

- [x] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
