### PR TITLE
feat: add bot details as message properties

### DIFF
--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -64,15 +64,15 @@ type MessageProperties struct {
 	Stage                string    `json:"stage,omitempty"`                // optional
 	Compression          string    `json:"compression,omitempty"`          // optional
 	Encryption           string    `json:"encryption,omitempty"`           // optional
-	IsBot                bool      `json:"isBot,omitempty"`                // optional
+	// if key is rotated EncryptionKeyID should be used to refer to correct key
+	EncryptionKeyID string `json:"encryptionKeyID,omitempty"` // optional
+	IsBot           bool   `json:"isBot,omitempty"`           // optional
 	// BotName is the name of the bot that sent the event
 	BotName string `json:"botName,omitempty"` // optional
-	// BotURL is the reference URL why the detected BotName in user agent is labeled as a bot
+	// BotURL contains the source URL or reference that explains why the user agent was identified as a bot
 	BotURL string `json:"botURL,omitempty"` // optional
 	// BotIsInvalidBrowser is true if event is a bot and the browser is invalid
 	BotIsInvalidBrowser bool `json:"botIsInvalidBrowser,omitempty"` // optional
-	// if key is rotated EncryptionKeyID should be used to refer to correct key
-	EncryptionKeyID string `json:"encryptionKeyID,omitempty"` // optional
 }
 
 func (m MessageProperties) LoggerFields() []logger.Field {
@@ -188,7 +188,7 @@ func ToMapProperties(properties MessageProperties) map[string]string {
 		m[mapKeyStage] = properties.Stage
 	}
 	if properties.IsBot {
-		m[mapKeyIsBot] = strconv.FormatBool(properties.IsBot)
+		m[mapKeyIsBot] = "true"
 		m[mapKeyBotName] = properties.BotName
 		m[mapKeyBotURL] = properties.BotURL
 		m[mapKeyBotIsInvalidBrowser] = strconv.FormatBool(properties.BotIsInvalidBrowser)

--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -115,6 +115,8 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 	}
 
 	var isBot, botIsInvalidBrowser bool
+	var botName, botURL string
+
 	if properties[mapKeyIsBot] != "" {
 		isBot, err = strconv.ParseBool(properties[mapKeyIsBot])
 		if err != nil {
@@ -122,10 +124,15 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		}
 	}
 
-	if isBot && properties[mapKeyBotIsInvalidBrowser] != "" {
-		botIsInvalidBrowser, err = strconv.ParseBool(properties[mapKeyBotIsInvalidBrowser])
-		if err != nil {
-			return MessageProperties{}, fmt.Errorf("parsing botIsInvalidBrowser: %w", err)
+	if isBot {
+		botName = properties[mapKeyBotName]
+		botURL = properties[mapKeyBotURL]
+
+		if properties[mapKeyBotIsInvalidBrowser] != "" {
+			botIsInvalidBrowser, err = strconv.ParseBool(properties[mapKeyBotIsInvalidBrowser])
+			if err != nil {
+				return MessageProperties{}, fmt.Errorf("parsing botIsInvalidBrowser: %w", err)
+			}
 		}
 	}
 
@@ -148,8 +155,8 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		Encryption:           properties[mapKeyEncryption],
 		EncryptionKeyID:      properties[mapKeyEncryptionKeyID],
 		IsBot:                isBot,
-		BotName:              properties[mapKeyBotName],
-		BotURL:               properties[mapKeyBotURL],
+		BotName:              botName,
+		BotURL:               botURL,
 		BotIsInvalidBrowser:  botIsInvalidBrowser,
 	}, nil
 }

--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -34,7 +34,7 @@ const (
 	mapKeyIsBot                = "isBot"
 	mapKeyBotName              = "botName"
 	mapKeyBotURL               = "botURL"
-	mapKeyBotUnknownBrowser    = "botUnknownBrowser"
+	mapKeyBotIsInvalidBrowser  = "botIsInvalidBrowser"
 )
 
 var (
@@ -67,7 +67,7 @@ type MessageProperties struct {
 	IsBot                bool      `json:"isBot,omitempty"`                // optional
 	BotName              string    `json:"botName,omitempty"`              // optional
 	BotURL               string    `json:"botURL,omitempty"`               // optional
-	BotUnknownBrowser    bool      `json:"botUnknownBrowser,omitempty"`    // optional
+	BotIsInvalidBrowser  bool      `json:"botIsInvalidBrowser,omitempty"`  // optional
 	// if key is rotated EncryptionKeyID should be used to refer to correct key
 	EncryptionKeyID string `json:"encryptionKeyID,omitempty"` // optional
 }
@@ -99,9 +99,11 @@ func (m MessageProperties) LoggerFields() []logger.Field {
 	fields = append(fields, logger.NewStringField(mapKeyEncryption, m.Encryption))
 	fields = append(fields, logger.NewStringField(mapKeyEncryptionKeyID, m.EncryptionKeyID))
 	fields = append(fields, logger.NewBoolField(mapKeyIsBot, m.IsBot))
-	fields = append(fields, logger.NewStringField(mapKeyBotName, m.BotName))
-	fields = append(fields, logger.NewStringField(mapKeyBotURL, m.BotURL))
-	fields = append(fields, logger.NewBoolField(mapKeyBotUnknownBrowser, m.BotUnknownBrowser))
+	if m.IsBot {
+		fields = append(fields, logger.NewStringField(mapKeyBotName, m.BotName))
+		fields = append(fields, logger.NewStringField(mapKeyBotURL, m.BotURL))
+		fields = append(fields, logger.NewBoolField(mapKeyBotIsInvalidBrowser, m.BotIsInvalidBrowser))
+	}
 	return fields
 }
 
@@ -112,7 +114,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		return MessageProperties{}, fmt.Errorf("parsing receivedAt: %w", err)
 	}
 
-	var isBot, botUnknownBrowser bool
+	var isBot, botIsInvalidBrowser bool
 	if properties[mapKeyIsBot] != "" {
 		isBot, err = strconv.ParseBool(properties[mapKeyIsBot])
 		if err != nil {
@@ -120,10 +122,10 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		}
 	}
 
-	if properties[mapKeyBotUnknownBrowser] != "" {
-		botUnknownBrowser, err = strconv.ParseBool(properties[mapKeyBotUnknownBrowser])
+	if isBot && properties[mapKeyBotIsInvalidBrowser] != "" {
+		botIsInvalidBrowser, err = strconv.ParseBool(properties[mapKeyBotIsInvalidBrowser])
 		if err != nil {
-			return MessageProperties{}, fmt.Errorf("parsing botUnknownBrowser: %w", err)
+			return MessageProperties{}, fmt.Errorf("parsing botIsInvalidBrowser: %w", err)
 		}
 	}
 
@@ -148,7 +150,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		IsBot:                isBot,
 		BotName:              properties[mapKeyBotName],
 		BotURL:               properties[mapKeyBotURL],
-		BotUnknownBrowser:    botUnknownBrowser,
+		BotIsInvalidBrowser:  botIsInvalidBrowser,
 	}, nil
 }
 
@@ -179,7 +181,7 @@ func ToMapProperties(properties MessageProperties) map[string]string {
 		m[mapKeyIsBot] = strconv.FormatBool(properties.IsBot)
 		m[mapKeyBotName] = properties.BotName
 		m[mapKeyBotURL] = properties.BotURL
-		m[mapKeyBotUnknownBrowser] = strconv.FormatBool(properties.BotUnknownBrowser)
+		m[mapKeyBotIsInvalidBrowser] = strconv.FormatBool(properties.BotIsInvalidBrowser)
 	}
 	return m
 }

--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -65,9 +65,12 @@ type MessageProperties struct {
 	Compression          string    `json:"compression,omitempty"`          // optional
 	Encryption           string    `json:"encryption,omitempty"`           // optional
 	IsBot                bool      `json:"isBot,omitempty"`                // optional
-	BotName              string    `json:"botName,omitempty"`              // optional
-	BotURL               string    `json:"botURL,omitempty"`               // optional
-	BotIsInvalidBrowser  bool      `json:"botIsInvalidBrowser,omitempty"`  // optional
+	// BotName is the name of the bot that sent the event
+	BotName string `json:"botName,omitempty"` // optional
+	// BotURL is the reference URL why the detected BotName in user agent is labeled as a bot
+	BotURL string `json:"botURL,omitempty"` // optional
+	// BotIsInvalidBrowser is true if event is a bot and the browser is invalid
+	BotIsInvalidBrowser bool `json:"botIsInvalidBrowser,omitempty"` // optional
 	// if key is rotated EncryptionKeyID should be used to refer to correct key
 	EncryptionKeyID string `json:"encryptionKeyID,omitempty"` // optional
 }

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -181,6 +181,30 @@ func TestMessage(t *testing.T) {
 			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
 		})
 
+		t.Run("botIsInvalidBrowser, botName, botURL should not be set even if they are present if isBot is false", func(t *testing.T) {
+			// botIsInvalidBrowser, botName, botURL should not be present if isBot is false, this case should not happen in production
+			msg, err := stream.FromMapProperties(map[string]string{
+				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"isBot":               "false",
+				"botIsInvalidBrowser": "true",
+				"botName":             "TestBot",
+				"botURL":              "https://testbot.com",
+			})
+			require.NoError(t, err)
+
+			require.False(t, msg.IsBot)
+			require.Empty(t, msg.BotName)
+			require.Empty(t, msg.BotURL)
+			require.False(t, msg.BotIsInvalidBrowser)
+
+			propertiesOut := stream.ToMapProperties(msg)
+
+			require.NotContains(t, propertiesOut, "isBot")
+			require.NotContains(t, propertiesOut, "botName")
+			require.NotContains(t, propertiesOut, "botURL")
+			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
+		})
+
 		t.Run("invalid isBot format", func(t *testing.T) {
 			msg, err := stream.FromMapProperties(map[string]string{
 				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),


### PR DESCRIPTION
# Description

This PR adds 4 new fields in message properties, which will be used for flagging bot events
- `isBot` (bool): Indicates whether the event originated from a bot
- `botName` (string): Identifies the specific bot name when detected
- `botURL` (string): Provides reference information about why the source was identified as a bot
- `botIsInvalidBrowser` (bool): Flags requests from unknown browsers (when true, `isBot` will also be true)

## Linear Ticket

< Replace_with_Linear_Link >

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
