### PR TITLE
feat: add botAction field to message properties

### DIFF
--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -14,28 +14,28 @@ import (
 const (
 	StageWebhook = "webhook"
 
-	mapKeyRequestType          = "requestType"
-	mapKeyRoutingKey           = "routingKey"
-	mapKeyWorkspaceID          = "workspaceID"
-	mapKeySourceID             = "sourceID"
-	mapKeyDestinationID        = "destinationID"
-	mapKeyRequestIP            = "requestIP"
-	mapKeyReceivedAt           = "receivedAt"
-	mapKeyUserID               = "userID"
-	mapKeySourceJobRunID       = "sourceJobRunID"
-	mapKeySourceTaskRunID      = "sourceTaskRunID"
-	mapKeyTraceID              = "traceID"
-	mapKeySourceType           = "sourceType"
-	mapKeyWebhookFailureReason = "webhookFailureReason"
-	mapKeyStage                = "stage"
-	mapKeyCompression          = "compression"
-	mapKeyEncryption           = "encryption"
-	mapKeyEncryptionKeyID      = "encryptionKeyID"
-	mapKeyIsBot                = "isBot"
-	mapKeyBotName              = "botName"
-	mapKeyBotURL               = "botURL"
-	mapKeyBotIsInvalidBrowser  = "botIsInvalidBrowser"
-	mapKeyNeedsBotEnrichment   = "needsBotEnrichment"
+	mapKeyRequestType           = "requestType"
+	mapKeyRoutingKey            = "routingKey"
+	mapKeyWorkspaceID           = "workspaceID"
+	mapKeySourceID              = "sourceID"
+	mapKeyDestinationID         = "destinationID"
+	mapKeyRequestIP             = "requestIP"
+	mapKeyReceivedAt            = "receivedAt"
+	mapKeyUserID                = "userID"
+	mapKeySourceJobRunID        = "sourceJobRunID"
+	mapKeySourceTaskRunID       = "sourceTaskRunID"
+	mapKeyTraceID               = "traceID"
+	mapKeySourceType            = "sourceType"
+	mapKeyWebhookFailureReason  = "webhookFailureReason"
+	mapKeyStage                 = "stage"
+	mapKeyCompression           = "compression"
+	mapKeyEncryption            = "encryption"
+	mapKeyEncryptionKeyID       = "encryptionKeyID"
+	mapKeyIsBot                 = "isBot"
+	mapKeyBotName               = "botName"
+	mapKeyBotURL                = "botURL"
+	mapKeyBotIsInvalidBrowser   = "botIsInvalidBrowser"
+	mapKeyRequiresBotEnrichment = "requiresBotEnrichment"
 )
 
 var (
@@ -74,8 +74,8 @@ type MessageProperties struct {
 	BotURL string `json:"botURL,omitempty"` // optional
 	// BotIsInvalidBrowser is true if event is a bot and the browser is invalid
 	BotIsInvalidBrowser bool `json:"botIsInvalidBrowser,omitempty"` // optional
-	// NeedsBotEnrichment is true if event should be enriched with bot details
-	NeedsBotEnrichment bool `json:"needsBotEnrichment,omitempty"` // optional
+	// RequiresBotEnrichment is true if event should be enriched with bot details
+	RequiresBotEnrichment bool `json:"requiresBotEnrichment,omitempty"` // optional
 }
 
 func (m MessageProperties) LoggerFields() []logger.Field {
@@ -109,7 +109,7 @@ func (m MessageProperties) LoggerFields() []logger.Field {
 		fields = append(fields, logger.NewStringField(mapKeyBotName, m.BotName))
 		fields = append(fields, logger.NewStringField(mapKeyBotURL, m.BotURL))
 		fields = append(fields, logger.NewBoolField(mapKeyBotIsInvalidBrowser, m.BotIsInvalidBrowser))
-		fields = append(fields, logger.NewBoolField(mapKeyNeedsBotEnrichment, m.NeedsBotEnrichment))
+		fields = append(fields, logger.NewBoolField(mapKeyRequiresBotEnrichment, m.RequiresBotEnrichment))
 	}
 	return fields
 }
@@ -121,7 +121,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		return MessageProperties{}, fmt.Errorf("parsing receivedAt: %w", err)
 	}
 
-	var isBot, botIsInvalidBrowser, needsBotEnrichment bool
+	var isBot, botIsInvalidBrowser, requiresBotEnrichment bool
 	var botName, botURL string
 
 	if properties[mapKeyIsBot] != "" {
@@ -142,37 +142,37 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 			}
 		}
 
-		if properties[mapKeyNeedsBotEnrichment] != "" {
-			needsBotEnrichment, err = strconv.ParseBool(properties[mapKeyNeedsBotEnrichment])
+		if properties[mapKeyRequiresBotEnrichment] != "" {
+			requiresBotEnrichment, err = strconv.ParseBool(properties[mapKeyRequiresBotEnrichment])
 			if err != nil {
-				return MessageProperties{}, fmt.Errorf("parsing needsBotEnrichment: %w", err)
+				return MessageProperties{}, fmt.Errorf("parsing requiresBotEnrichment: %w", err)
 			}
 		}
 	}
 
 	return MessageProperties{
-		RequestType:          properties[mapKeyRequestType],
-		RoutingKey:           properties[mapKeyRoutingKey],
-		WorkspaceID:          properties[mapKeyWorkspaceID],
-		RequestIP:            properties[mapKeyRequestIP],
-		UserID:               properties[mapKeyUserID],
-		SourceID:             properties[mapKeySourceID],
-		DestinationID:        properties[mapKeyDestinationID],
-		ReceivedAt:           receivedAt,
-		SourceJobRunID:       properties[mapKeySourceJobRunID],
-		SourceTaskRunID:      properties[mapKeySourceTaskRunID],
-		TraceID:              properties[mapKeyTraceID],
-		SourceType:           properties[mapKeySourceType],
-		WebhookFailureReason: properties[mapKeyWebhookFailureReason],
-		Stage:                properties[mapKeyStage],
-		Compression:          properties[mapKeyCompression],
-		Encryption:           properties[mapKeyEncryption],
-		EncryptionKeyID:      properties[mapKeyEncryptionKeyID],
-		IsBot:                isBot,
-		BotName:              botName,
-		BotURL:               botURL,
-		BotIsInvalidBrowser:  botIsInvalidBrowser,
-		NeedsBotEnrichment:   needsBotEnrichment,
+		RequestType:           properties[mapKeyRequestType],
+		RoutingKey:            properties[mapKeyRoutingKey],
+		WorkspaceID:           properties[mapKeyWorkspaceID],
+		RequestIP:             properties[mapKeyRequestIP],
+		UserID:                properties[mapKeyUserID],
+		SourceID:              properties[mapKeySourceID],
+		DestinationID:         properties[mapKeyDestinationID],
+		ReceivedAt:            receivedAt,
+		SourceJobRunID:        properties[mapKeySourceJobRunID],
+		SourceTaskRunID:       properties[mapKeySourceTaskRunID],
+		TraceID:               properties[mapKeyTraceID],
+		SourceType:            properties[mapKeySourceType],
+		WebhookFailureReason:  properties[mapKeyWebhookFailureReason],
+		Stage:                 properties[mapKeyStage],
+		Compression:           properties[mapKeyCompression],
+		Encryption:            properties[mapKeyEncryption],
+		EncryptionKeyID:       properties[mapKeyEncryptionKeyID],
+		IsBot:                 isBot,
+		BotName:               botName,
+		BotURL:                botURL,
+		BotIsInvalidBrowser:   botIsInvalidBrowser,
+		RequiresBotEnrichment: requiresBotEnrichment,
 	}, nil
 }
 
@@ -204,7 +204,7 @@ func ToMapProperties(properties MessageProperties) map[string]string {
 		m[mapKeyBotName] = properties.BotName
 		m[mapKeyBotURL] = properties.BotURL
 		m[mapKeyBotIsInvalidBrowser] = strconv.FormatBool(properties.BotIsInvalidBrowser)
-		m[mapKeyNeedsBotEnrichment] = strconv.FormatBool(properties.NeedsBotEnrichment)
+		m[mapKeyRequiresBotEnrichment] = strconv.FormatBool(properties.RequiresBotEnrichment)
 	}
 	return m
 }

--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -35,6 +35,7 @@ const (
 	mapKeyBotName              = "botName"
 	mapKeyBotURL               = "botURL"
 	mapKeyBotIsInvalidBrowser  = "botIsInvalidBrowser"
+	mapKeyShouldFlagBot        = "shouldFlagBot"
 )
 
 var (
@@ -73,6 +74,8 @@ type MessageProperties struct {
 	BotURL string `json:"botURL,omitempty"` // optional
 	// BotIsInvalidBrowser is true if event is a bot and the browser is invalid
 	BotIsInvalidBrowser bool `json:"botIsInvalidBrowser,omitempty"` // optional
+	// ShouldFlagBot is true if the event should be flagged as a bot
+	ShouldFlagBot bool `json:"shouldFlagBot,omitempty"` // optional
 }
 
 func (m MessageProperties) LoggerFields() []logger.Field {
@@ -106,6 +109,7 @@ func (m MessageProperties) LoggerFields() []logger.Field {
 		fields = append(fields, logger.NewStringField(mapKeyBotName, m.BotName))
 		fields = append(fields, logger.NewStringField(mapKeyBotURL, m.BotURL))
 		fields = append(fields, logger.NewBoolField(mapKeyBotIsInvalidBrowser, m.BotIsInvalidBrowser))
+		fields = append(fields, logger.NewBoolField(mapKeyShouldFlagBot, m.ShouldFlagBot))
 	}
 	return fields
 }
@@ -117,7 +121,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		return MessageProperties{}, fmt.Errorf("parsing receivedAt: %w", err)
 	}
 
-	var isBot, botIsInvalidBrowser bool
+	var isBot, botIsInvalidBrowser, shouldFlagBot bool
 	var botName, botURL string
 
 	if properties[mapKeyIsBot] != "" {
@@ -135,6 +139,13 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 			botIsInvalidBrowser, err = strconv.ParseBool(properties[mapKeyBotIsInvalidBrowser])
 			if err != nil {
 				return MessageProperties{}, fmt.Errorf("parsing botIsInvalidBrowser: %w", err)
+			}
+		}
+
+		if properties[mapKeyShouldFlagBot] != "" {
+			shouldFlagBot, err = strconv.ParseBool(properties[mapKeyShouldFlagBot])
+			if err != nil {
+				return MessageProperties{}, fmt.Errorf("parsing shouldFlagBot: %w", err)
 			}
 		}
 	}
@@ -161,6 +172,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		BotName:              botName,
 		BotURL:               botURL,
 		BotIsInvalidBrowser:  botIsInvalidBrowser,
+		ShouldFlagBot:        shouldFlagBot,
 	}, nil
 }
 
@@ -192,6 +204,7 @@ func ToMapProperties(properties MessageProperties) map[string]string {
 		m[mapKeyBotName] = properties.BotName
 		m[mapKeyBotURL] = properties.BotURL
 		m[mapKeyBotIsInvalidBrowser] = strconv.FormatBool(properties.BotIsInvalidBrowser)
+		m[mapKeyShouldFlagBot] = strconv.FormatBool(properties.ShouldFlagBot)
 	}
 	return m
 }

--- a/go/stream/message.go
+++ b/go/stream/message.go
@@ -35,7 +35,7 @@ const (
 	mapKeyBotName              = "botName"
 	mapKeyBotURL               = "botURL"
 	mapKeyBotIsInvalidBrowser  = "botIsInvalidBrowser"
-	mapKeyShouldFlagBot        = "shouldFlagBot"
+	mapKeyNeedsBotEnrichment   = "needsBotEnrichment"
 )
 
 var (
@@ -74,8 +74,8 @@ type MessageProperties struct {
 	BotURL string `json:"botURL,omitempty"` // optional
 	// BotIsInvalidBrowser is true if event is a bot and the browser is invalid
 	BotIsInvalidBrowser bool `json:"botIsInvalidBrowser,omitempty"` // optional
-	// ShouldFlagBot is true if the event should be flagged as a bot
-	ShouldFlagBot bool `json:"shouldFlagBot,omitempty"` // optional
+	// NeedsBotEnrichment is true if event should be enriched with bot details
+	NeedsBotEnrichment bool `json:"needsBotEnrichment,omitempty"` // optional
 }
 
 func (m MessageProperties) LoggerFields() []logger.Field {
@@ -109,7 +109,7 @@ func (m MessageProperties) LoggerFields() []logger.Field {
 		fields = append(fields, logger.NewStringField(mapKeyBotName, m.BotName))
 		fields = append(fields, logger.NewStringField(mapKeyBotURL, m.BotURL))
 		fields = append(fields, logger.NewBoolField(mapKeyBotIsInvalidBrowser, m.BotIsInvalidBrowser))
-		fields = append(fields, logger.NewBoolField(mapKeyShouldFlagBot, m.ShouldFlagBot))
+		fields = append(fields, logger.NewBoolField(mapKeyNeedsBotEnrichment, m.NeedsBotEnrichment))
 	}
 	return fields
 }
@@ -121,7 +121,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		return MessageProperties{}, fmt.Errorf("parsing receivedAt: %w", err)
 	}
 
-	var isBot, botIsInvalidBrowser, shouldFlagBot bool
+	var isBot, botIsInvalidBrowser, needsBotEnrichment bool
 	var botName, botURL string
 
 	if properties[mapKeyIsBot] != "" {
@@ -142,10 +142,10 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 			}
 		}
 
-		if properties[mapKeyShouldFlagBot] != "" {
-			shouldFlagBot, err = strconv.ParseBool(properties[mapKeyShouldFlagBot])
+		if properties[mapKeyNeedsBotEnrichment] != "" {
+			needsBotEnrichment, err = strconv.ParseBool(properties[mapKeyNeedsBotEnrichment])
 			if err != nil {
-				return MessageProperties{}, fmt.Errorf("parsing shouldFlagBot: %w", err)
+				return MessageProperties{}, fmt.Errorf("parsing needsBotEnrichment: %w", err)
 			}
 		}
 	}
@@ -172,7 +172,7 @@ func FromMapProperties(properties map[string]string) (MessageProperties, error) 
 		BotName:              botName,
 		BotURL:               botURL,
 		BotIsInvalidBrowser:  botIsInvalidBrowser,
-		ShouldFlagBot:        shouldFlagBot,
+		NeedsBotEnrichment:   needsBotEnrichment,
 	}, nil
 }
 
@@ -204,7 +204,7 @@ func ToMapProperties(properties MessageProperties) map[string]string {
 		m[mapKeyBotName] = properties.BotName
 		m[mapKeyBotURL] = properties.BotURL
 		m[mapKeyBotIsInvalidBrowser] = strconv.FormatBool(properties.BotIsInvalidBrowser)
-		m[mapKeyShouldFlagBot] = strconv.FormatBool(properties.ShouldFlagBot)
+		m[mapKeyNeedsBotEnrichment] = strconv.FormatBool(properties.NeedsBotEnrichment)
 	}
 	return m
 }

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -111,104 +111,52 @@ func TestMessage(t *testing.T) {
 	})
 
 	t.Run("properties to/from: pulsar with bot fields", func(t *testing.T) {
-		t.Run("isBot is true and requiresBotEnrichment is false", func(t *testing.T) {
+		t.Run("isBot is true", func(t *testing.T) {
 			input := map[string]string{
-				"requestType":           "requestType",
-				"routingKey":            "routingKey",
-				"workspaceID":           "workspaceID",
-				"userID":                "userID",
-				"sourceID":              "sourceID",
-				"destinationID":         "destinationID",
-				"requestIP":             "10.29.13.20",
-				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"sourceJobRunID":        "sourceJobRunID",
-				"sourceTaskRunID":       "sourceTaskRunID",
-				"traceID":               "traceID",
-				"compression":           "some-serialized-compression-settings",
-				"encryption":            "some-serialized-encryption-settings",
-				"encryptionKeyID":       "encryptionKeyID",
-				"isBot":                 "true",
-				"botName":               "TestBot",
-				"botURL":                "https://testbot.com",
-				"botIsInvalidBrowser":   "true",
-				"requiresBotEnrichment": "false",
+				"requestType":         "requestType",
+				"routingKey":          "routingKey",
+				"workspaceID":         "workspaceID",
+				"userID":              "userID",
+				"sourceID":            "sourceID",
+				"destinationID":       "destinationID",
+				"requestIP":           "10.29.13.20",
+				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"sourceJobRunID":      "sourceJobRunID",
+				"sourceTaskRunID":     "sourceTaskRunID",
+				"traceID":             "traceID",
+				"compression":         "some-serialized-compression-settings",
+				"encryption":          "some-serialized-encryption-settings",
+				"encryptionKeyID":     "encryptionKeyID",
+				"isBot":               "true",
+				"botName":             "TestBot",
+				"botURL":              "https://testbot.com",
+				"botIsInvalidBrowser": "true",
+				"botAction":           "flag",
 			}
 
 			msg, err := stream.FromMapProperties(input)
 			require.NoError(t, err)
 
 			require.Equal(t, stream.MessageProperties{
-				RequestType:           "requestType",
-				RoutingKey:            "routingKey",
-				WorkspaceID:           "workspaceID",
-				UserID:                "userID",
-				SourceID:              "sourceID",
-				DestinationID:         "destinationID",
-				RequestIP:             "10.29.13.20",
-				ReceivedAt:            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
-				SourceJobRunID:        "sourceJobRunID",
-				SourceTaskRunID:       "sourceTaskRunID",
-				TraceID:               "traceID",
-				Compression:           "some-serialized-compression-settings",
-				Encryption:            "some-serialized-encryption-settings",
-				EncryptionKeyID:       "encryptionKeyID",
-				IsBot:                 true,
-				BotName:               "TestBot",
-				BotURL:                "https://testbot.com",
-				BotIsInvalidBrowser:   true,
-				RequiresBotEnrichment: false,
-			}, msg)
-
-			propertiesOut := stream.ToMapProperties(msg)
-			require.Equal(t, input, propertiesOut)
-		})
-
-		t.Run("isBot and requiresBotEnrichment is true", func(t *testing.T) {
-			input := map[string]string{
-				"requestType":           "requestType",
-				"routingKey":            "routingKey",
-				"workspaceID":           "workspaceID",
-				"userID":                "userID",
-				"sourceID":              "sourceID",
-				"destinationID":         "destinationID",
-				"requestIP":             "10.29.13.20",
-				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"sourceJobRunID":        "sourceJobRunID",
-				"sourceTaskRunID":       "sourceTaskRunID",
-				"traceID":               "traceID",
-				"compression":           "some-serialized-compression-settings",
-				"encryption":            "some-serialized-encryption-settings",
-				"encryptionKeyID":       "encryptionKeyID",
-				"isBot":                 "true",
-				"botName":               "TestBot",
-				"botURL":                "https://testbot.com",
-				"botIsInvalidBrowser":   "true",
-				"requiresBotEnrichment": "true",
-			}
-
-			msg, err := stream.FromMapProperties(input)
-			require.NoError(t, err)
-
-			require.Equal(t, stream.MessageProperties{
-				RequestType:           "requestType",
-				RoutingKey:            "routingKey",
-				WorkspaceID:           "workspaceID",
-				UserID:                "userID",
-				SourceID:              "sourceID",
-				DestinationID:         "destinationID",
-				RequestIP:             "10.29.13.20",
-				ReceivedAt:            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
-				SourceJobRunID:        "sourceJobRunID",
-				SourceTaskRunID:       "sourceTaskRunID",
-				TraceID:               "traceID",
-				Compression:           "some-serialized-compression-settings",
-				Encryption:            "some-serialized-encryption-settings",
-				EncryptionKeyID:       "encryptionKeyID",
-				IsBot:                 true,
-				BotName:               "TestBot",
-				BotURL:                "https://testbot.com",
-				BotIsInvalidBrowser:   true,
-				RequiresBotEnrichment: true,
+				RequestType:         "requestType",
+				RoutingKey:          "routingKey",
+				WorkspaceID:         "workspaceID",
+				UserID:              "userID",
+				SourceID:            "sourceID",
+				DestinationID:       "destinationID",
+				RequestIP:           "10.29.13.20",
+				ReceivedAt:          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
+				SourceJobRunID:      "sourceJobRunID",
+				SourceTaskRunID:     "sourceTaskRunID",
+				TraceID:             "traceID",
+				Compression:         "some-serialized-compression-settings",
+				Encryption:          "some-serialized-encryption-settings",
+				EncryptionKeyID:     "encryptionKeyID",
+				IsBot:               true,
+				BotName:             "TestBot",
+				BotURL:              "https://testbot.com",
+				BotIsInvalidBrowser: true,
+				BotAction:           "flag",
 			}, msg)
 
 			propertiesOut := stream.ToMapProperties(msg)
@@ -226,6 +174,7 @@ func TestMessage(t *testing.T) {
 			require.Empty(t, msg.BotName)
 			require.Empty(t, msg.BotURL)
 			require.False(t, msg.BotIsInvalidBrowser)
+			require.Empty(t, msg.BotAction)
 
 			propertiesOut := stream.ToMapProperties(msg)
 
@@ -233,18 +182,18 @@ func TestMessage(t *testing.T) {
 			require.NotContains(t, propertiesOut, "botName")
 			require.NotContains(t, propertiesOut, "botURL")
 			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
-			require.NotContains(t, propertiesOut, "requiresBotEnrichment")
+			require.NotContains(t, propertiesOut, "botAction")
 		})
 
-		t.Run("botIsInvalidBrowser, botName, botURL, requiresBotEnrichment should not be set even if they are present if isBot is false", func(t *testing.T) {
+		t.Run("botIsInvalidBrowser, botName, botURL should not be set even if they are present if isBot is false", func(t *testing.T) {
 			// botIsInvalidBrowser, botName, botURL should not be present if isBot is false, this case should not happen in production
 			msg, err := stream.FromMapProperties(map[string]string{
-				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"isBot":                 "false",
-				"botIsInvalidBrowser":   "true",
-				"botName":               "TestBot",
-				"botURL":                "https://testbot.com",
-				"requiresBotEnrichment": "true",
+				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"isBot":               "false",
+				"botIsInvalidBrowser": "true",
+				"botName":             "TestBot",
+				"botURL":              "https://testbot.com",
+				"botAction":           "flag",
 			})
 			require.NoError(t, err)
 
@@ -252,6 +201,7 @@ func TestMessage(t *testing.T) {
 			require.Empty(t, msg.BotName)
 			require.Empty(t, msg.BotURL)
 			require.False(t, msg.BotIsInvalidBrowser)
+			require.Empty(t, msg.BotAction)
 
 			propertiesOut := stream.ToMapProperties(msg)
 
@@ -259,7 +209,7 @@ func TestMessage(t *testing.T) {
 			require.NotContains(t, propertiesOut, "botName")
 			require.NotContains(t, propertiesOut, "botURL")
 			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
-			require.NotContains(t, propertiesOut, "requiresBotEnrichment")
+			require.NotContains(t, propertiesOut, "botAction")
 		})
 
 		t.Run("invalid isBot format", func(t *testing.T) {
@@ -280,16 +230,6 @@ func TestMessage(t *testing.T) {
 			})
 			require.Empty(t, msg)
 			require.EqualError(t, err, `parsing botIsInvalidBrowser: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
-		})
-
-		t.Run("invalid requiresBotEnrichment format", func(t *testing.T) {
-			msg, err := stream.FromMapProperties(map[string]string{
-				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"isBot":                 "true",
-				"requiresBotEnrichment": "not-a-boolean",
-			})
-			require.Empty(t, msg)
-			require.EqualError(t, err, `parsing requiresBotEnrichment: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
 		})
 	})
 
@@ -440,7 +380,8 @@ func TestMessage(t *testing.T) {
 				"isBot": true,
 				"botName": "TestBot",
 				"botURL": "https://testbot.com",
-				"botIsInvalidBrowser": true
+				"botIsInvalidBrowser": true,
+				"botAction": "flag"
 			},
 			"payload": {
 				"key": "value"
@@ -467,64 +408,7 @@ func TestMessage(t *testing.T) {
 				BotName:             "TestBot",
 				BotURL:              "https://testbot.com",
 				BotIsInvalidBrowser: true,
-			},
-			Payload: json.RawMessage(`{
-				"key": "value"
-			}`),
-		}, msg)
-
-		output, err := json.Marshal(msg)
-		require.NoError(t, err)
-		require.JSONEq(t, input, string(output))
-	})
-
-	t.Run("message to/from: JSON with requiresBotEnrichment", func(t *testing.T) {
-		input := `
-		{
-			"properties": {
-				"requestType": "requestType",
-				"routingKey": "routingKey",
-				"workspaceID": "workspaceID",
-				"userID": "userID",
-				"sourceID": "sourceID",
-				"destinationID": "destinationID",
-				"receivedAt": "2024-08-01T02:30:50.0000002Z",
-				"requestIP": "10.29.13.20",
-				"sourceJobRunID": "sourceJobRunID",
-				"sourceTaskRunID": "sourceTaskRunID",
-				"traceID": "traceID",
-				"isBot": true,
-				"botName": "TestBot",
-				"botURL": "https://testbot.com",
-				"botIsInvalidBrowser": true,
-				"requiresBotEnrichment": true
-			},
-			"payload": {
-				"key": "value"
-			}
-		}`
-
-		msg := stream.Message{}
-		err := json.Unmarshal([]byte(input), &msg)
-		require.NoError(t, err)
-		require.Equal(t, stream.Message{
-			Properties: stream.MessageProperties{
-				RequestType:           "requestType",
-				RoutingKey:            "routingKey",
-				WorkspaceID:           "workspaceID",
-				UserID:                "userID",
-				SourceID:              "sourceID",
-				DestinationID:         "destinationID",
-				RequestIP:             "10.29.13.20",
-				ReceivedAt:            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
-				SourceJobRunID:        "sourceJobRunID",
-				SourceTaskRunID:       "sourceTaskRunID",
-				TraceID:               "traceID",
-				IsBot:                 true,
-				BotName:               "TestBot",
-				BotURL:                "https://testbot.com",
-				BotIsInvalidBrowser:   true,
-				RequiresBotEnrichment: true,
+				BotAction:           "flag",
 			},
 			Payload: json.RawMessage(`{
 				"key": "value"
@@ -724,26 +608,26 @@ func TestMessage(t *testing.T) {
 
 	t.Run("logger fields - bot fields", func(t *testing.T) {
 		properties := stream.MessageProperties{
-			RequestType:           "requestType",
-			RoutingKey:            "routingKey",
-			WorkspaceID:           "workspaceID",
-			SourceID:              "sourceID",
-			ReceivedAt:            time.Date(2024, 8, 1, 2, 30, 50, 200, time.UTC),
-			RequestIP:             "10.29.13.20",
-			DestinationID:         "destinationID",
-			UserID:                "userID",
-			SourceJobRunID:        "sourceJobRunID",
-			SourceTaskRunID:       "sourceTaskRunID",
-			TraceID:               "traceID",
-			SourceType:            "sourceType",
-			Compression:           "some-serialized-compression-settings",
-			Encryption:            "some-serialized-encryption-settings",
-			EncryptionKeyID:       "encryptionKeyID",
-			IsBot:                 true,
-			BotName:               "TestBot",
-			BotURL:                "https://testbot.com",
-			BotIsInvalidBrowser:   true,
-			RequiresBotEnrichment: true,
+			RequestType:         "requestType",
+			RoutingKey:          "routingKey",
+			WorkspaceID:         "workspaceID",
+			SourceID:            "sourceID",
+			ReceivedAt:          time.Date(2024, 8, 1, 2, 30, 50, 200, time.UTC),
+			RequestIP:           "10.29.13.20",
+			DestinationID:       "destinationID",
+			UserID:              "userID",
+			SourceJobRunID:      "sourceJobRunID",
+			SourceTaskRunID:     "sourceTaskRunID",
+			TraceID:             "traceID",
+			SourceType:          "sourceType",
+			Compression:         "some-serialized-compression-settings",
+			Encryption:          "some-serialized-encryption-settings",
+			EncryptionKeyID:     "encryptionKeyID",
+			IsBot:               true,
+			BotName:             "TestBot",
+			BotURL:              "https://testbot.com",
+			BotIsInvalidBrowser: true,
+			BotAction:           "flag",
 		}
 
 		expectedFields := []logger.Field{
@@ -765,7 +649,7 @@ func TestMessage(t *testing.T) {
 			logger.NewStringField("botName", "TestBot"),
 			logger.NewStringField("botURL", "https://testbot.com"),
 			logger.NewBoolField("botIsInvalidBrowser", true),
-			logger.NewBoolField("requiresBotEnrichment", true),
+			logger.NewStringField("botAction", "flag"),
 		}
 
 		require.ElementsMatch(t, expectedFields, properties.LoggerFields())

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -111,7 +111,7 @@ func TestMessage(t *testing.T) {
 	})
 
 	t.Run("properties to/from: pulsar with bot fields", func(t *testing.T) {
-		t.Run("isBot is true and shouldFlagBot is false", func(t *testing.T) {
+		t.Run("isBot is true and needsBotEnrichment is false", func(t *testing.T) {
 			input := map[string]string{
 				"requestType":         "requestType",
 				"routingKey":          "routingKey",
@@ -131,7 +131,7 @@ func TestMessage(t *testing.T) {
 				"botName":             "TestBot",
 				"botURL":              "https://testbot.com",
 				"botIsInvalidBrowser": "true",
-				"shouldFlagBot":       "false",
+				"needsBotEnrichment":  "false",
 			}
 
 			msg, err := stream.FromMapProperties(input)
@@ -156,14 +156,14 @@ func TestMessage(t *testing.T) {
 				BotName:             "TestBot",
 				BotURL:              "https://testbot.com",
 				BotIsInvalidBrowser: true,
-				ShouldFlagBot:       false,
+				NeedsBotEnrichment:  false,
 			}, msg)
 
 			propertiesOut := stream.ToMapProperties(msg)
 			require.Equal(t, input, propertiesOut)
 		})
 
-		t.Run("isBot and shouldFlagBot is true", func(t *testing.T) {
+		t.Run("isBot and needsBotEnrichment is true", func(t *testing.T) {
 			input := map[string]string{
 				"requestType":         "requestType",
 				"routingKey":          "routingKey",
@@ -183,7 +183,7 @@ func TestMessage(t *testing.T) {
 				"botName":             "TestBot",
 				"botURL":              "https://testbot.com",
 				"botIsInvalidBrowser": "true",
-				"shouldFlagBot":       "true",
+				"needsBotEnrichment":  "true",
 			}
 
 			msg, err := stream.FromMapProperties(input)
@@ -208,7 +208,7 @@ func TestMessage(t *testing.T) {
 				BotName:             "TestBot",
 				BotURL:              "https://testbot.com",
 				BotIsInvalidBrowser: true,
-				ShouldFlagBot:       true,
+				NeedsBotEnrichment:  true,
 			}, msg)
 
 			propertiesOut := stream.ToMapProperties(msg)
@@ -233,10 +233,10 @@ func TestMessage(t *testing.T) {
 			require.NotContains(t, propertiesOut, "botName")
 			require.NotContains(t, propertiesOut, "botURL")
 			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
-			require.NotContains(t, propertiesOut, "shouldFlagBot")
+			require.NotContains(t, propertiesOut, "needsBotEnrichment")
 		})
 
-		t.Run("botIsInvalidBrowser, botName, botURL, shouldFlagBot should not be set even if they are present if isBot is false", func(t *testing.T) {
+		t.Run("botIsInvalidBrowser, botName, botURL, needsBotEnrichment should not be set even if they are present if isBot is false", func(t *testing.T) {
 			// botIsInvalidBrowser, botName, botURL should not be present if isBot is false, this case should not happen in production
 			msg, err := stream.FromMapProperties(map[string]string{
 				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
@@ -244,7 +244,7 @@ func TestMessage(t *testing.T) {
 				"botIsInvalidBrowser": "true",
 				"botName":             "TestBot",
 				"botURL":              "https://testbot.com",
-				"shouldFlagBot":       "true",
+				"needsBotEnrichment":  "true",
 			})
 			require.NoError(t, err)
 
@@ -259,7 +259,7 @@ func TestMessage(t *testing.T) {
 			require.NotContains(t, propertiesOut, "botName")
 			require.NotContains(t, propertiesOut, "botURL")
 			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
-			require.NotContains(t, propertiesOut, "shouldFlagBot")
+			require.NotContains(t, propertiesOut, "needsBotEnrichment")
 		})
 
 		t.Run("invalid isBot format", func(t *testing.T) {
@@ -282,14 +282,14 @@ func TestMessage(t *testing.T) {
 			require.EqualError(t, err, `parsing botIsInvalidBrowser: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
 		})
 
-		t.Run("invalid shouldFlagBot format", func(t *testing.T) {
+		t.Run("invalid needsBotEnrichment format", func(t *testing.T) {
 			msg, err := stream.FromMapProperties(map[string]string{
-				"receivedAt":    time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"isBot":         "true",
-				"shouldFlagBot": "not-a-boolean",
+				"receivedAt":         time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"isBot":              "true",
+				"needsBotEnrichment": "not-a-boolean",
 			})
 			require.Empty(t, msg)
-			require.EqualError(t, err, `parsing shouldFlagBot: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
+			require.EqualError(t, err, `parsing needsBotEnrichment: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
 		})
 	})
 
@@ -478,7 +478,7 @@ func TestMessage(t *testing.T) {
 		require.JSONEq(t, input, string(output))
 	})
 
-	t.Run("message to/from: JSON with shouldFlagBot", func(t *testing.T) {
+	t.Run("message to/from: JSON with needsBotEnrichment", func(t *testing.T) {
 		input := `
 		{
 			"properties": {
@@ -497,7 +497,7 @@ func TestMessage(t *testing.T) {
 				"botName": "TestBot",
 				"botURL": "https://testbot.com",
 				"botIsInvalidBrowser": true,
-				"shouldFlagBot": true
+				"needsBotEnrichment": true
 			},
 			"payload": {
 				"key": "value"
@@ -524,7 +524,7 @@ func TestMessage(t *testing.T) {
 				BotName:             "TestBot",
 				BotURL:              "https://testbot.com",
 				BotIsInvalidBrowser: true,
-				ShouldFlagBot:       true,
+				NeedsBotEnrichment:  true,
 			},
 			Payload: json.RawMessage(`{
 				"key": "value"
@@ -743,7 +743,7 @@ func TestMessage(t *testing.T) {
 			BotName:             "TestBot",
 			BotURL:              "https://testbot.com",
 			BotIsInvalidBrowser: true,
-			ShouldFlagBot:       true,
+			NeedsBotEnrichment:  true,
 		}
 
 		expectedFields := []logger.Field{
@@ -765,7 +765,7 @@ func TestMessage(t *testing.T) {
 			logger.NewStringField("botName", "TestBot"),
 			logger.NewStringField("botURL", "https://testbot.com"),
 			logger.NewBoolField("botIsInvalidBrowser", true),
-			logger.NewBoolField("shouldFlagBot", true),
+			logger.NewBoolField("needsBotEnrichment", true),
 		}
 
 		require.ElementsMatch(t, expectedFields, properties.LoggerFields())

--- a/go/stream/message_test.go
+++ b/go/stream/message_test.go
@@ -111,104 +111,104 @@ func TestMessage(t *testing.T) {
 	})
 
 	t.Run("properties to/from: pulsar with bot fields", func(t *testing.T) {
-		t.Run("isBot is true and needsBotEnrichment is false", func(t *testing.T) {
+		t.Run("isBot is true and requiresBotEnrichment is false", func(t *testing.T) {
 			input := map[string]string{
-				"requestType":         "requestType",
-				"routingKey":          "routingKey",
-				"workspaceID":         "workspaceID",
-				"userID":              "userID",
-				"sourceID":            "sourceID",
-				"destinationID":       "destinationID",
-				"requestIP":           "10.29.13.20",
-				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"sourceJobRunID":      "sourceJobRunID",
-				"sourceTaskRunID":     "sourceTaskRunID",
-				"traceID":             "traceID",
-				"compression":         "some-serialized-compression-settings",
-				"encryption":          "some-serialized-encryption-settings",
-				"encryptionKeyID":     "encryptionKeyID",
-				"isBot":               "true",
-				"botName":             "TestBot",
-				"botURL":              "https://testbot.com",
-				"botIsInvalidBrowser": "true",
-				"needsBotEnrichment":  "false",
+				"requestType":           "requestType",
+				"routingKey":            "routingKey",
+				"workspaceID":           "workspaceID",
+				"userID":                "userID",
+				"sourceID":              "sourceID",
+				"destinationID":         "destinationID",
+				"requestIP":             "10.29.13.20",
+				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"sourceJobRunID":        "sourceJobRunID",
+				"sourceTaskRunID":       "sourceTaskRunID",
+				"traceID":               "traceID",
+				"compression":           "some-serialized-compression-settings",
+				"encryption":            "some-serialized-encryption-settings",
+				"encryptionKeyID":       "encryptionKeyID",
+				"isBot":                 "true",
+				"botName":               "TestBot",
+				"botURL":                "https://testbot.com",
+				"botIsInvalidBrowser":   "true",
+				"requiresBotEnrichment": "false",
 			}
 
 			msg, err := stream.FromMapProperties(input)
 			require.NoError(t, err)
 
 			require.Equal(t, stream.MessageProperties{
-				RequestType:         "requestType",
-				RoutingKey:          "routingKey",
-				WorkspaceID:         "workspaceID",
-				UserID:              "userID",
-				SourceID:            "sourceID",
-				DestinationID:       "destinationID",
-				RequestIP:           "10.29.13.20",
-				ReceivedAt:          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
-				SourceJobRunID:      "sourceJobRunID",
-				SourceTaskRunID:     "sourceTaskRunID",
-				TraceID:             "traceID",
-				Compression:         "some-serialized-compression-settings",
-				Encryption:          "some-serialized-encryption-settings",
-				EncryptionKeyID:     "encryptionKeyID",
-				IsBot:               true,
-				BotName:             "TestBot",
-				BotURL:              "https://testbot.com",
-				BotIsInvalidBrowser: true,
-				NeedsBotEnrichment:  false,
+				RequestType:           "requestType",
+				RoutingKey:            "routingKey",
+				WorkspaceID:           "workspaceID",
+				UserID:                "userID",
+				SourceID:              "sourceID",
+				DestinationID:         "destinationID",
+				RequestIP:             "10.29.13.20",
+				ReceivedAt:            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
+				SourceJobRunID:        "sourceJobRunID",
+				SourceTaskRunID:       "sourceTaskRunID",
+				TraceID:               "traceID",
+				Compression:           "some-serialized-compression-settings",
+				Encryption:            "some-serialized-encryption-settings",
+				EncryptionKeyID:       "encryptionKeyID",
+				IsBot:                 true,
+				BotName:               "TestBot",
+				BotURL:                "https://testbot.com",
+				BotIsInvalidBrowser:   true,
+				RequiresBotEnrichment: false,
 			}, msg)
 
 			propertiesOut := stream.ToMapProperties(msg)
 			require.Equal(t, input, propertiesOut)
 		})
 
-		t.Run("isBot and needsBotEnrichment is true", func(t *testing.T) {
+		t.Run("isBot and requiresBotEnrichment is true", func(t *testing.T) {
 			input := map[string]string{
-				"requestType":         "requestType",
-				"routingKey":          "routingKey",
-				"workspaceID":         "workspaceID",
-				"userID":              "userID",
-				"sourceID":            "sourceID",
-				"destinationID":       "destinationID",
-				"requestIP":           "10.29.13.20",
-				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"sourceJobRunID":      "sourceJobRunID",
-				"sourceTaskRunID":     "sourceTaskRunID",
-				"traceID":             "traceID",
-				"compression":         "some-serialized-compression-settings",
-				"encryption":          "some-serialized-encryption-settings",
-				"encryptionKeyID":     "encryptionKeyID",
-				"isBot":               "true",
-				"botName":             "TestBot",
-				"botURL":              "https://testbot.com",
-				"botIsInvalidBrowser": "true",
-				"needsBotEnrichment":  "true",
+				"requestType":           "requestType",
+				"routingKey":            "routingKey",
+				"workspaceID":           "workspaceID",
+				"userID":                "userID",
+				"sourceID":              "sourceID",
+				"destinationID":         "destinationID",
+				"requestIP":             "10.29.13.20",
+				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"sourceJobRunID":        "sourceJobRunID",
+				"sourceTaskRunID":       "sourceTaskRunID",
+				"traceID":               "traceID",
+				"compression":           "some-serialized-compression-settings",
+				"encryption":            "some-serialized-encryption-settings",
+				"encryptionKeyID":       "encryptionKeyID",
+				"isBot":                 "true",
+				"botName":               "TestBot",
+				"botURL":                "https://testbot.com",
+				"botIsInvalidBrowser":   "true",
+				"requiresBotEnrichment": "true",
 			}
 
 			msg, err := stream.FromMapProperties(input)
 			require.NoError(t, err)
 
 			require.Equal(t, stream.MessageProperties{
-				RequestType:         "requestType",
-				RoutingKey:          "routingKey",
-				WorkspaceID:         "workspaceID",
-				UserID:              "userID",
-				SourceID:            "sourceID",
-				DestinationID:       "destinationID",
-				RequestIP:           "10.29.13.20",
-				ReceivedAt:          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
-				SourceJobRunID:      "sourceJobRunID",
-				SourceTaskRunID:     "sourceTaskRunID",
-				TraceID:             "traceID",
-				Compression:         "some-serialized-compression-settings",
-				Encryption:          "some-serialized-encryption-settings",
-				EncryptionKeyID:     "encryptionKeyID",
-				IsBot:               true,
-				BotName:             "TestBot",
-				BotURL:              "https://testbot.com",
-				BotIsInvalidBrowser: true,
-				NeedsBotEnrichment:  true,
+				RequestType:           "requestType",
+				RoutingKey:            "routingKey",
+				WorkspaceID:           "workspaceID",
+				UserID:                "userID",
+				SourceID:              "sourceID",
+				DestinationID:         "destinationID",
+				RequestIP:             "10.29.13.20",
+				ReceivedAt:            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
+				SourceJobRunID:        "sourceJobRunID",
+				SourceTaskRunID:       "sourceTaskRunID",
+				TraceID:               "traceID",
+				Compression:           "some-serialized-compression-settings",
+				Encryption:            "some-serialized-encryption-settings",
+				EncryptionKeyID:       "encryptionKeyID",
+				IsBot:                 true,
+				BotName:               "TestBot",
+				BotURL:                "https://testbot.com",
+				BotIsInvalidBrowser:   true,
+				RequiresBotEnrichment: true,
 			}, msg)
 
 			propertiesOut := stream.ToMapProperties(msg)
@@ -233,18 +233,18 @@ func TestMessage(t *testing.T) {
 			require.NotContains(t, propertiesOut, "botName")
 			require.NotContains(t, propertiesOut, "botURL")
 			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
-			require.NotContains(t, propertiesOut, "needsBotEnrichment")
+			require.NotContains(t, propertiesOut, "requiresBotEnrichment")
 		})
 
-		t.Run("botIsInvalidBrowser, botName, botURL, needsBotEnrichment should not be set even if they are present if isBot is false", func(t *testing.T) {
+		t.Run("botIsInvalidBrowser, botName, botURL, requiresBotEnrichment should not be set even if they are present if isBot is false", func(t *testing.T) {
 			// botIsInvalidBrowser, botName, botURL should not be present if isBot is false, this case should not happen in production
 			msg, err := stream.FromMapProperties(map[string]string{
-				"receivedAt":          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"isBot":               "false",
-				"botIsInvalidBrowser": "true",
-				"botName":             "TestBot",
-				"botURL":              "https://testbot.com",
-				"needsBotEnrichment":  "true",
+				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"isBot":                 "false",
+				"botIsInvalidBrowser":   "true",
+				"botName":               "TestBot",
+				"botURL":                "https://testbot.com",
+				"requiresBotEnrichment": "true",
 			})
 			require.NoError(t, err)
 
@@ -259,7 +259,7 @@ func TestMessage(t *testing.T) {
 			require.NotContains(t, propertiesOut, "botName")
 			require.NotContains(t, propertiesOut, "botURL")
 			require.NotContains(t, propertiesOut, "botIsInvalidBrowser")
-			require.NotContains(t, propertiesOut, "needsBotEnrichment")
+			require.NotContains(t, propertiesOut, "requiresBotEnrichment")
 		})
 
 		t.Run("invalid isBot format", func(t *testing.T) {
@@ -282,14 +282,14 @@ func TestMessage(t *testing.T) {
 			require.EqualError(t, err, `parsing botIsInvalidBrowser: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
 		})
 
-		t.Run("invalid needsBotEnrichment format", func(t *testing.T) {
+		t.Run("invalid requiresBotEnrichment format", func(t *testing.T) {
 			msg, err := stream.FromMapProperties(map[string]string{
-				"receivedAt":         time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
-				"isBot":              "true",
-				"needsBotEnrichment": "not-a-boolean",
+				"receivedAt":            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC).Format(time.RFC3339Nano),
+				"isBot":                 "true",
+				"requiresBotEnrichment": "not-a-boolean",
 			})
 			require.Empty(t, msg)
-			require.EqualError(t, err, `parsing needsBotEnrichment: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
+			require.EqualError(t, err, `parsing requiresBotEnrichment: strconv.ParseBool: parsing "not-a-boolean": invalid syntax`)
 		})
 	})
 
@@ -478,7 +478,7 @@ func TestMessage(t *testing.T) {
 		require.JSONEq(t, input, string(output))
 	})
 
-	t.Run("message to/from: JSON with needsBotEnrichment", func(t *testing.T) {
+	t.Run("message to/from: JSON with requiresBotEnrichment", func(t *testing.T) {
 		input := `
 		{
 			"properties": {
@@ -497,7 +497,7 @@ func TestMessage(t *testing.T) {
 				"botName": "TestBot",
 				"botURL": "https://testbot.com",
 				"botIsInvalidBrowser": true,
-				"needsBotEnrichment": true
+				"requiresBotEnrichment": true
 			},
 			"payload": {
 				"key": "value"
@@ -509,22 +509,22 @@ func TestMessage(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, stream.Message{
 			Properties: stream.MessageProperties{
-				RequestType:         "requestType",
-				RoutingKey:          "routingKey",
-				WorkspaceID:         "workspaceID",
-				UserID:              "userID",
-				SourceID:            "sourceID",
-				DestinationID:       "destinationID",
-				RequestIP:           "10.29.13.20",
-				ReceivedAt:          time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
-				SourceJobRunID:      "sourceJobRunID",
-				SourceTaskRunID:     "sourceTaskRunID",
-				TraceID:             "traceID",
-				IsBot:               true,
-				BotName:             "TestBot",
-				BotURL:              "https://testbot.com",
-				BotIsInvalidBrowser: true,
-				NeedsBotEnrichment:  true,
+				RequestType:           "requestType",
+				RoutingKey:            "routingKey",
+				WorkspaceID:           "workspaceID",
+				UserID:                "userID",
+				SourceID:              "sourceID",
+				DestinationID:         "destinationID",
+				RequestIP:             "10.29.13.20",
+				ReceivedAt:            time.Date(2024, 8, 1, 0o2, 30, 50, 200, time.UTC),
+				SourceJobRunID:        "sourceJobRunID",
+				SourceTaskRunID:       "sourceTaskRunID",
+				TraceID:               "traceID",
+				IsBot:                 true,
+				BotName:               "TestBot",
+				BotURL:                "https://testbot.com",
+				BotIsInvalidBrowser:   true,
+				RequiresBotEnrichment: true,
 			},
 			Payload: json.RawMessage(`{
 				"key": "value"
@@ -724,26 +724,26 @@ func TestMessage(t *testing.T) {
 
 	t.Run("logger fields - bot fields", func(t *testing.T) {
 		properties := stream.MessageProperties{
-			RequestType:         "requestType",
-			RoutingKey:          "routingKey",
-			WorkspaceID:         "workspaceID",
-			SourceID:            "sourceID",
-			ReceivedAt:          time.Date(2024, 8, 1, 2, 30, 50, 200, time.UTC),
-			RequestIP:           "10.29.13.20",
-			DestinationID:       "destinationID",
-			UserID:              "userID",
-			SourceJobRunID:      "sourceJobRunID",
-			SourceTaskRunID:     "sourceTaskRunID",
-			TraceID:             "traceID",
-			SourceType:          "sourceType",
-			Compression:         "some-serialized-compression-settings",
-			Encryption:          "some-serialized-encryption-settings",
-			EncryptionKeyID:     "encryptionKeyID",
-			IsBot:               true,
-			BotName:             "TestBot",
-			BotURL:              "https://testbot.com",
-			BotIsInvalidBrowser: true,
-			NeedsBotEnrichment:  true,
+			RequestType:           "requestType",
+			RoutingKey:            "routingKey",
+			WorkspaceID:           "workspaceID",
+			SourceID:              "sourceID",
+			ReceivedAt:            time.Date(2024, 8, 1, 2, 30, 50, 200, time.UTC),
+			RequestIP:             "10.29.13.20",
+			DestinationID:         "destinationID",
+			UserID:                "userID",
+			SourceJobRunID:        "sourceJobRunID",
+			SourceTaskRunID:       "sourceTaskRunID",
+			TraceID:               "traceID",
+			SourceType:            "sourceType",
+			Compression:           "some-serialized-compression-settings",
+			Encryption:            "some-serialized-encryption-settings",
+			EncryptionKeyID:       "encryptionKeyID",
+			IsBot:                 true,
+			BotName:               "TestBot",
+			BotURL:                "https://testbot.com",
+			BotIsInvalidBrowser:   true,
+			RequiresBotEnrichment: true,
 		}
 
 		expectedFields := []logger.Field{
@@ -765,7 +765,7 @@ func TestMessage(t *testing.T) {
 			logger.NewStringField("botName", "TestBot"),
 			logger.NewStringField("botURL", "https://testbot.com"),
 			logger.NewBoolField("botIsInvalidBrowser", true),
-			logger.NewBoolField("needsBotEnrichment", true),
+			logger.NewBoolField("requiresBotEnrichment", true),
 		}
 
 		require.ElementsMatch(t, expectedFields, properties.LoggerFields())


### PR DESCRIPTION
# Description
## Description

This PR introduces a new string field `botAction` to event message properties. This field will be set by the ingestion service and read by the processor to determine whether an event identified as a bot event should be enriched with additional bot details (e.g., bot name, URL).

## Motivation and Context

This change is driven by the need to provide more accurate bot event metrics and offer more granular control over bot event handling.

Currently, customers enabling the "flag" bot setting often see a discrepancy between bot metrics from the ingestion service and the actual count of bot events in their data warehouse. This is largely because the processor deduplicates a significant number of bot events.

To address this, we aim to introduce a new, more accurate metric: "ingested bot count." This metric will be emitted by the processor after its deduplication logic, providing a reliable count of bot events that are actually processed and forwarded to the destination.

However, for the processor to emit this "ingested bot count" metric accurately, it needs access to bot identification details (like isBot, botName) from the message properties for all events identified as bots, regardless of whether they are to be fully enriched. The current system couples bot identification with enrichment: isBot is only set to true by the ingestion service if the processor is also supposed to enrich the event.

The ingestion service can now consistently include bot identification details (isBot = true, botName, etc.) in message properties whenever a bot is detected.
The processor then uses the`botAction` flag to determine if the enrichment step (adding more bot details like URL, etc.) should occur.

## How it Works

-   **Ingestion Service:**
    -   Will continue to identify bot events and set `isBot = true` along with other available bot details (e.g., `botName`).
    -   Will set the new `botAction` field (e.g., to `flag` if the user has configured to flag bot events, `disable` if the user opted not to act).
-   **Processor:**
    -   Will read the `isBot` from the message properties to identify bot events for the "ingested bot count" metric.
    -   Will check the `botAction` flag. If the value is `flag`, it will proceed with enriching the event with further bot details. or else it will skip the enrichment step, even if `isBot` is true.


## Linear Ticket

Resolves OBS-845

## Security

- [ ] The code changed/added as part of this pull request won't create any security issues with how the software is being used.
